### PR TITLE
fix(graph)!: strip <think> tags and return cleaned report

### DIFF
--- a/email_summarizer/.env.example
+++ b/email_summarizer/.env.example
@@ -5,7 +5,8 @@ EXCHANGE_PASSWORD=your_password
 EXCHANGE_SERVER=your_exchange_server
 
 # Azure OpenAI API
-AZURE_OPENAI_API_KEY = your_azure_openai_api_key
+DEEP_THINK_LLM_KEY=your_deep_think_llm_key
+QUICK_THINK_LLM_KEY=your_quick_think_llm_key
 
 # Celery Config
 CELERY_BROKER_URL=redis://localhost:6379/0

--- a/email_summarizer/app/agents/graph/email_summarizer_graph.py
+++ b/email_summarizer/app/agents/graph/email_summarizer_graph.py
@@ -23,6 +23,7 @@ from email_summarizer.app.config import Config
 from .conditional_logic import ConditionalLogic
 from .setup import GraphSetup
 from .propagation import Propagator
+import re
 
 class EmailSummarizerAgentsGraph:
     """Main class that orchestrates the email summarization agents framework."""
@@ -130,6 +131,16 @@ class EmailSummarizerAgentsGraph:
             ),
         }
 
+    def _clean_final_report_format(self, report: str) -> str:
+        """Clean and format the final report string. Remove <think></think> tags.
+
+        Args:
+            report: Raw report string
+        """
+        regex = r"<think>[\s\S]*?<\/think>"
+        cleaned_report = re.sub(regex, "", report).strip()
+        return cleaned_report
+    
     def propagate(self, emails, email_summarization_date):
         logger.debug(f"🔍 [GRAPH DEBUG] ===== EmailSummarizer.propagate 接收参数 =====")
         logger.debug(f"🔍 [GRAPH DEBUG] 接收到的emails: '{emails}' (类型: {type(emails)})")
@@ -156,4 +167,5 @@ class EmailSummarizerAgentsGraph:
             final_state = self.graph.invoke(init_agent_state, **args)
 
         self.curr_state = final_state
-        return final_state
+        final_report = self._clean_final_report_format(final_state["email_summary_report"])
+        return final_report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "celery>=5.5.3",
     "exchangelib>=5.5.1",
+    "fastapi>=0.116.2",
     "ipykernel>=6.30.1",
     "langchain-community>=0.3.29",
     "langchain-ollama>=0.3.8",
@@ -18,5 +19,6 @@ dependencies = [
     "pyyaml>=6.0.2",
     "streamlit>=1.49.1",
     "toml>=0.10.2",
+    "uvicorn>=0.35.0",
     "watchdog>=6.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -609,6 +609,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "celery" },
     { name = "exchangelib" },
+    { name = "fastapi" },
     { name = "ipykernel" },
     { name = "langchain-community" },
     { name = "langchain-ollama" },
@@ -620,6 +621,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "streamlit" },
     { name = "toml" },
+    { name = "uvicorn" },
     { name = "watchdog" },
 ]
 
@@ -627,6 +629,7 @@ dependencies = [
 requires-dist = [
     { name = "celery", specifier = ">=5.5.3" },
     { name = "exchangelib", specifier = ">=5.5.1" },
+    { name = "fastapi", specifier = ">=0.116.2" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "langchain-community", specifier = ">=0.3.29" },
     { name = "langchain-ollama", specifier = ">=0.3.8" },
@@ -638,6 +641,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "streamlit", specifier = ">=1.49.1" },
     { name = "toml", specifier = ">=0.10.2" },
+    { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "watchdog", specifier = ">=6.0.0" },
 ]
 
@@ -683,6 +687,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.116.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/64/1296f46d6b9e3b23fb22e5d01af3f104ef411425531376212f1eefa2794d/fastapi-0.116.2.tar.gz", hash = "sha256:231a6af2fe21cfa2c32730170ad8514985fc250bec16c9b242d3b94c835ef529", size = 298595, upload-time = "2025-09-16T18:29:23.058Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/e4/c543271a8018874b7f682bf6156863c416e1334b8ed3e51a69495c5d4360/fastapi-0.116.2-py3-none-any.whl", hash = "sha256:c3a7a8fb830b05f7e087d920e0d786ca1fc9892eb4e9a84b227be4c1bc7569db", size = 95670, upload-time = "2025-09-16T18:29:21.329Z" },
 ]
 
 [[package]]
@@ -3230,6 +3248,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
 name = "streamlit"
 version = "1.49.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3427,6 +3458,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/42/e0e305207bb88c6b8d3061399c6a961ffe5fbb7e2aa63c9234df7259e9cd/uvicorn-0.35.0.tar.gz", hash = "sha256:bc662f087f7cf2ce11a1d7fd70b90c9f98ef2e2831556dd078d131b96cc94a01", size = 78473, upload-time = "2025-06-28T16:15:46.058Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/e2/dc81b1bd1dcfe91735810265e9d26bc8ec5da45b4c0f6237e286819194c3/uvicorn-0.35.0-py3-none-any.whl", hash = "sha256:197535216b25ff9b785e29a0b79199f55222193d47f820816e7da751e9bc8d4a", size = 66406, upload-time = "2025-06-28T16:15:44.816Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add _clean_final_report_format to remove <think>...</think> blocks from LLM output and trim whitespace
- Use cleaned report in propagate() to prevent leaking internal reasoning to users and improve downstream parsing
- Update .env.example: replace AZURE_OPENAI_API_KEY with DEEP_THINK_LLM_KEY and QUICK_THINK_LLM_KEY to reflect dual-LLM config
- Add FastAPI and Uvicorn to project dependencies; update lockfile

BREAKING CHANGE: propagate() now returns the cleaned report string instead of the full agent state dict. Update callers accordingly.

## Summary by Sourcery

Strip internal <think> reasoning tags from the final report and return the cleaned summary string from propagate(), add dual-LLM environment variables, and include FastAPI and Uvicorn dependencies

Enhancements:
- Add _clean_final_report_format to remove <think>…</think> blocks and trim whitespace from LLM output
- Modify propagate() to return only the cleaned report string instead of the full agent state

Build:
- Add FastAPI and Uvicorn to project dependencies

Documentation:
- Update .env.example to rename AZURE_OPENAI_API_KEY to DEEP_THINK_LLM_KEY and QUICK_THINK_LLM_KEY to support dual-LLM configuration