### PR TITLE
fix(email-graph): return dict state and clean report

### DIFF
--- a/email_summarizer/app/agents/graph/email_summarizer_graph.py
+++ b/email_summarizer/app/agents/graph/email_summarizer_graph.py
@@ -167,5 +167,18 @@ class EmailSummarizerAgentsGraph:
             final_state = self.graph.invoke(init_agent_state, **args)
 
         self.curr_state = final_state
-        final_report = self._clean_final_report_format(final_state["email_summary_report"])
-        return final_report
+
+        # Ensure we return a dict-compatible state for upstream callers
+        if isinstance(final_state, dict):
+            report = final_state.get("email_summary_report", "")
+            if not isinstance(report, str):
+                report = str(report)
+            cleaned = self._clean_final_report_format(report)
+            final_state["email_summary_report"] = cleaned
+            return final_state
+        elif isinstance(final_state, str):
+            cleaned = self._clean_final_report_format(final_state)
+            return {"email_summary_report": cleaned}
+        else:
+            logger.error(f"Unexpected final_state type from graph: {type(final_state)}; value: {final_state}")
+            raise TypeError(f"Unexpected final_state type from graph: {type(final_state)}")


### PR DESCRIPTION
Standardize the graph result handling to always return a dict with email_summary_report. This ensures upstream callers receive a dict-compatible state.

- If final_state is a dict: coerce report to string, clean it, set it back, and return the dict
- If final_state is a string: clean it and wrap in a dict
- Log and raise TypeError for unexpected types

This fixes type mismatches where a raw string was returned and guards against inconsistent graph outputs.

## Summary by Sourcery

Standardize graph result handling to always return a dict with cleaned email_summary_report.

Bug Fixes:
- Prevent raw string returns by wrapping string outputs into dict and cleaning the report.

Enhancements:
- Coerce non-string report values to string and raise a TypeError with logging on unexpected final_state types.